### PR TITLE
Harden subprocess calls and fix benchmarking metrics

### DIFF
--- a/src/ahot_benchmark.py
+++ b/src/ahot_benchmark.py
@@ -5,17 +5,15 @@ import time
 import json
 import psutil
 import platform
-import subprocess
-import os
 from pathlib import Path
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, List, Optional
 import numpy as np
 import matplotlib.pyplot as plt
 import seaborn as sns
 from dataclasses import dataclass, asdict
 import logging
 
-from ahot import AHOTFactory, HardwareAnalyzer, ProductionMonitor
+from ahot import AHOTFactory, HardwareAnalyzer
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -134,7 +132,7 @@ class AHOTBenchmarker:
             
             # Decoding
             start_time = time.time()
-            decoded_text = tokenizer.decode(tokens)
+            _ = tokenizer.decode(tokens)
             decoding_time = (time.time() - start_time) * 1000
             
             # Memory measurement after
@@ -148,7 +146,7 @@ class AHOTBenchmarker:
             decoding_times.append(decoding_time)
             compression_ratios.append(info['performance']['compression_ratio'])
             memory_usages.append(memory_after - memory_before)
-            if gpu_memory_before and gpu_memory_after:
+            if gpu_memory_before is not None and gpu_memory_after is not None:
                 gpu_memory_usages.append(gpu_memory_after - gpu_memory_before)
         
         # Calculate averages


### PR DESCRIPTION
## Summary
- safeguard hardware inspection subprocess calls by resolving absolute command paths
- correct compression layer to use computed output dimension
- fix GPU memory tracking in benchmarks to handle zero usage

## Testing
- `ruff check src`
- `python -m bandit -r src`
- `python -m py_compile src/ahot.py src/ahot_benchmark.py`


------
https://chatgpt.com/codex/tasks/task_e_688dca7d4030832db9bf2a9ce6aeb287