### PR TITLE
Add basic CI for tests and PyPI releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+    tags: ["v*"]
+  pull_request:
+
+jobs:
+  build:
+    name: Lint and Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install flake8 pytest
+      - name: Lint
+        run: flake8 . --select=E9,F63,F7,F82 --show-source --statistics
+      - name: Test
+        run: pytest
+
+  publish:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Build package
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,7 @@ FUTURE_WORK.md
 
 # Package configuration
 setup.py
+
+# Allow GitHub workflow files
+!.github/workflows/*.yml
+!.github/workflows/*.yaml


### PR DESCRIPTION
## Summary
- add CI workflow to lint with flake8, run tests, and publish tagged releases to PyPI
- allow GitHub workflow YAML files to be versioned

## Testing
- `flake8 . --select=E9,F63,F7,F82`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688dd483bd64832db2328912ab4b8482